### PR TITLE
[GYJB-196] 노트 컨텐츠 수정 API 연동

### DIFF
--- a/src/partials/modals/LinkModal.tsx
+++ b/src/partials/modals/LinkModal.tsx
@@ -3,15 +3,15 @@ import useOnClickOutside from '../../hooks/useOnClickOutside';
 import useKeyPressESC from '../../hooks/useKeyPressESC';
 import {
   modalOpenState,
-  openedContentState,
-  termState,
   curCategoryIdState,
   contentsSizeState,
+  pageIdxState,
+  termState,
 } from '../../stores/dashboard';
-import { userCategoriesState, categoriesState } from '../../stores/category';
+import { userCategoriesState } from '../../stores/category';
 import { contentsState } from '../../stores/content';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { editLinkContent } from '../../utils/content';
+import { editLinkContent, getContents } from '../../utils/content';
 import { IEditLinkContent } from '../../typings/content';
 import useInput from '../../hooks/useInput';
 
@@ -28,6 +28,9 @@ const Modal = (props: IProps) => {
   const [selectedCategoryId, onChangeSelectedCategoryId] = useInput(null);
   const [title, onChangeTitle] = useInput(props.content.title);
   const curCategoryId = useRecoilValue(curCategoryIdState);
+  const [contentsSize, setContentsSize] = useRecoilState(contentsSizeState);
+  const [pageIdx, setPageIdx] = useRecoilState(pageIdxState);
+  const [term, setTerm] = useRecoilState(termState);
 
   useOnClickOutside(
     ref,
@@ -48,23 +51,20 @@ const Modal = (props: IProps) => {
     }
   }, []);
 
-  const editHandler = useCallback(() => {
+  const editHandler = () => {
+    setModalOpen(false);
+
     const body: IEditLinkContent = {
       categoryId: selectedCategoryId != 0 ? selectedCategoryId : null,
       title,
     };
 
-    editLinkContent(props.content.id, body).then((res) => {
-      if (!!curCategoryId) {
-        setContents([
-          ...contents.filter(
-            (item: any) => !item.category || item.category.id != curCategoryId,
-          ),
-        ]);
-      }
-      setModalOpen(false);
+    editLinkContent(props.content.id, body).then(() => {
+      getContents(contentsSize, curCategoryId, term, pageIdx).then((res) => {
+        setContents([...res]);
+      });
     });
-  }, [curCategoryId, selectedCategoryId, title, setModalOpen]);
+  };
 
   return (
     <div className="flex justify-center w-full">

--- a/src/partials/modals/NoteModal.tsx
+++ b/src/partials/modals/NoteModal.tsx
@@ -3,14 +3,15 @@ import useOnClickOutside from '../../hooks/useOnClickOutside';
 import useKeyPressESC from '../../hooks/useKeyPressESC';
 import {
   modalOpenState,
-  termState,
   curCategoryIdState,
   contentsSizeState,
+  pageIdxState,
+  termState,
 } from '../../stores/dashboard';
-import { userCategoriesState, categoriesState } from '../../stores/category';
+import { userCategoriesState } from '../../stores/category';
 import { contentsState } from '../../stores/content';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { editLinkContent } from '../../utils/content';
+import { editNoteContent, getContents } from '../../utils/content';
 import { IEditNoteContent } from '../../typings/content';
 import useInput from '../../hooks/useInput';
 
@@ -27,6 +28,9 @@ const Modal = (props: IProps) => {
   const [selectedCategoryId, onChangeSelectedCategoryId] = useInput(null);
   const [text, onChangeText] = useInput(props.content.text);
   const curCategoryId = useRecoilValue(curCategoryIdState);
+  const [contentsSize, setContentsSize] = useRecoilState(contentsSizeState);
+  const [pageIdx, setPageIdx] = useRecoilState(pageIdxState);
+  const [term, setTerm] = useRecoilState(termState);
 
   useOnClickOutside(
     ref,
@@ -47,13 +51,20 @@ const Modal = (props: IProps) => {
     }
   }, []);
 
-  const editHandler = useCallback(() => {
+  const editHandler = () => {
+    setModalOpen(false);
+
     const body: IEditNoteContent = {
       categoryId: selectedCategoryId != 0 ? selectedCategoryId : null,
       text,
     };
-    setModalOpen(false);
-  }, [curCategoryId, selectedCategoryId, text, setModalOpen]);
+
+    editNoteContent(props.content.id, body).then(() => {
+      getContents(contentsSize, curCategoryId, term, pageIdx).then((res) => {
+        setContents([...res]);
+      });
+    });
+  };
 
   return (
     <div className="flex justify-center w-full">

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -3,6 +3,7 @@ import {
   ILinkContent,
   INoteContent,
   IEditLinkContent,
+  IEditNoteContent,
 } from '../typings/content';
 import { parse } from './link';
 
@@ -67,7 +68,6 @@ export const editLinkContent = async (
   contentId: number,
   body: IEditLinkContent,
 ): Promise<any> => {
-  console.log('body', body);
   const response = await axios.patch(
     `${import.meta.env.VITE_API_SERVER}/content/v1/link/${contentId}`,
     body,
@@ -98,6 +98,27 @@ export const addNoteContent = async (content: {
     },
   );
 
+  return response.data;
+};
+
+/**
+ * 노트 컨텐츠의 내용 수정 함수
+ * @param {number} contentId
+ * @param {IEditNoteContent} body
+ * @returns {Promise<any>}
+ */
+export const editNoteContent = async (
+  contentId: number,
+  body: IEditNoteContent,
+): Promise<any> => {
+  const response = await axios.patch(
+    `${import.meta.env.VITE_API_SERVER}/content/v1/note/${contentId}`,
+    body,
+    {
+      withCredentials: true,
+      headers: { 'Content-Type': 'application/json' },
+    },
+  );
   return response.data;
 };
 


### PR DESCRIPTION
- 노트 컨텐츠 수정 API 연동
- 링크, 노트 컨텐츠 수정 후 결과 렌더링 방식 변경(서버로부터 모든 컨텐츠 요청한 결과 렌더링)
- 링크 컨텐츠 수정 useCallback 사용 중단