### PR TITLE
[GYJB-215] 서버 api 통신 헤더에access token 설정, 카테고리 삭제 버그 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "recoil": "^0.7.5",
     "sass": "^1.53.0",
     "tailwind-scrollbar-hide": "^1.1.7",
-    "ts-jest": "^28.0.7"
+    "ts-jest": "^28.0.7",
+    "vite-plugin-rewrite-all": "^1.0.0"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.2",

--- a/src/partials/buttons/CategoryOptionButton.tsx
+++ b/src/partials/buttons/CategoryOptionButton.tsx
@@ -11,6 +11,7 @@ import {
 import { deleteCategory } from '../../utils/category';
 import { contentsState } from '../../stores/content';
 import { IContents } from '../../typings/content';
+import { getContents } from '../../utils/content';
 
 interface IProps {
   categoryId: number | null;
@@ -22,7 +23,6 @@ const CategoryOptionButton = (props: IProps) => {
   const [editorOpen, setEditorOpen] = useState(false);
   const setEditCategoryId = useSetRecoilState(editCategoryIdState);
   const [categories, setCategories] = useRecoilState(userCategoriesState);
-  const [contents, setContents] = useRecoilState<IContents>(contentsState);
 
   useOnClickOutside(
     ref,
@@ -48,23 +48,25 @@ const CategoryOptionButton = (props: IProps) => {
   }, [dropdownOpen, editorOpen, setDropdownOpen, setEditorOpen]);
 
   const onDeleteHandler = useCallback(() => {
-    if (!!contents) {
-      alert('카테고리에 포함된 컨텐츠가 있어, 삭제를 할 수 없습니다.');
-      return;
-    }
-    if (props.categoryId) {
-      deleteCategory(props.categoryId).then((res) => {
-        if (res) {
-          setCategories([
-            ...categories.filter((item) => {
-              if (item.id && item.id !== props.categoryId) {
-                return item;
-              }
-            }),
-          ]);
-        }
-      });
-    }
+    getContents(1, props.categoryId).then((res) => {
+      if (!!res.length) {
+        alert('카테고리에 포함된 컨텐츠가 있어, 삭제를 할 수 없습니다.');
+        return;
+      }
+      if (props.categoryId) {
+        deleteCategory(props.categoryId).then((res) => {
+          if (res) {
+            setCategories([
+              ...categories.filter((item) => {
+                if (item.id && item.id !== props.categoryId) {
+                  return item;
+                }
+              }),
+            ]);
+          }
+        });
+      }
+    });
   }, []);
 
   return (

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -4,7 +4,6 @@ export const authHeader = (): AxiosRequestHeaders => {
   const temp = localStorage.getItem('accessToken');
   if (temp) {
     const accessToken = JSON.parse(temp);
-    console.log('accessToken', accessToken);
     return {
       Authorization: `Bearer ${accessToken}`,
       'Content-Type': 'application/json',

--- a/src/utils/category.ts
+++ b/src/utils/category.ts
@@ -41,8 +41,7 @@ export const addCategory = async (name: string) => {
   };
   return await axios
     .post(`${import.meta.env.VITE_API_SERVER}/category/v1`, body, {
-      withCredentials: true,
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeader(),
     })
     .then((response) => {
       return response.data.success;
@@ -65,8 +64,7 @@ export const editCategory = async (id: number, name: string) => {
   };
   return await axios
     .patch(`${import.meta.env.VITE_API_SERVER}/category/v1/${id}`, body, {
-      withCredentials: true,
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeader(),
     })
     .then((response) => {
       if (response.data.success) {
@@ -87,8 +85,7 @@ export const editCategory = async (id: number, name: string) => {
 export const deleteCategory = async (categoryId: number) => {
   return await axios
     .delete(`${import.meta.env.VITE_API_SERVER}/category/v1/${categoryId}`, {
-      withCredentials: true,
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeader(),
     })
     .then((response) => {
       return response.data.success;

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -67,8 +67,7 @@ export const getLinkContent = async (contentId: number): Promise<any> => {
   const response = await axios.get(
     `${import.meta.env.VITE_API_SERVER}/content/v1/${contentId}`,
     {
-      withCredentials: true,
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeader(),
     },
   );
 
@@ -89,8 +88,7 @@ export const editLinkContent = async (
     `${import.meta.env.VITE_API_SERVER}/content/v1/link/${contentId}`,
     body,
     {
-      withCredentials: true,
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeader(),
     },
   );
 
@@ -110,8 +108,7 @@ export const addNoteContent = async (content: {
     `${import.meta.env.VITE_API_SERVER}/content/v1/note`,
     content,
     {
-      withCredentials: true,
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeader(),
     },
   );
 
@@ -127,8 +124,7 @@ export const getNoteContent = async (contentId: number): Promise<any> => {
   const response = await axios.get(
     `${import.meta.env.VITE_API_SERVER}/content/v1/note/${contentId}`,
     {
-      withCredentials: true,
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeader(),
     },
   );
 
@@ -149,8 +145,7 @@ export const editNoteContent = async (
     `${import.meta.env.VITE_API_SERVER}/content/v1/note/${contentId}`,
     body,
     {
-      withCredentials: true,
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeader(),
     },
   );
   return response.data;
@@ -165,8 +160,7 @@ export const deleteContent = async (contentId: number): Promise<any> => {
   const response = await axios.delete(
     `${import.meta.env.VITE_API_SERVER}/content/v1/${contentId}`,
     {
-      withCredentials: true,
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeader(),
     },
   );
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import postcss from './postcss.config.js';
+import pluginRewriteAll from 'vite-plugin-rewrite-all';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -15,5 +16,5 @@ export default defineConfig({
       '/link': 'http://localhost:5050',
     },
   },
-  plugins: [react()],
+  plugins: [react(), pluginRewriteAll()],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1598,6 +1598,11 @@ confusing-browser-globals@^1.0.10:
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz#ae40e9b57cdd3915408a2805ebd3a5585608dc81"
   integrity sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==
 
+connect-history-api-fallback@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
+  integrity sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==
+
 convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.8.0.tgz#f3373c32d21b4d780dd8004514684fb791ca4369"
@@ -4287,6 +4292,13 @@ v8-to-istanbul@^9.0.1:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
+
+vite-plugin-rewrite-all@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/vite-plugin-rewrite-all/-/vite-plugin-rewrite-all-1.0.0.tgz#3a8e44f56d2c097186f1860712efb6835ec75d5f"
+  integrity sha512-XScNU1F73ImgsNQUuDTBd09r8nSz8Umr5PVhfmGJ8FTrFvfcci+P1pD7lT5BIdua75ZoNZGfHgdNYwnZB4cszQ==
+  dependencies:
+    connect-history-api-fallback "^1.6.0"
 
 vite@^2.9.9:
   version "2.9.14"


### PR DESCRIPTION
- 컨텐츠 및 카테고리 관련 서버와 통신 시, access token을 헤더에 설정
- 빈 카테고리도 여기에 소속된 컨텐츠가 있다고 판단되어 삭제가 안되는 버그 수정
- url에서 마침표가 포함된 경로를 허용하도록 설정(토큰 파싱을 위함)